### PR TITLE
Add failure and retry features to db connector

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -1,11 +1,38 @@
 var mysql = require('mysql');
-var connection = mysql.createConnection({
+var config = {
 	host	:'localhost',
 	user	:'root',
 	password : '',
 	database : 'hackertown'
-});
+};
 
-connection.connect();
+var connection;
+function setup() {
+	connection = mysql.createConnection(config);
+	connection.connect();
+	connection.on('error', function(err) {
+        console.log("connection error");
+		console.log(err);
+		setup();
+	});
+}
+setup();
 
-module.exports = connection;
+module.exports.escape = connection.escape;
+module.exports.query = function() {
+  var parameters = Array.prototype.slice.call(arguments);
+  var retry_count = 0;
+  var f = function() {
+    try {
+      connection.query.apply(connection, parameters);
+    } catch (e) {
+      console.log(e);
+      setup();
+      if (retry_count < 5) {
+        setTimeout(function() { f(); }, 100);
+        retry_count++;
+      }
+    }
+  };
+  f();
+}


### PR DESCRIPTION
This particular node module we are using for connecting to MySQL does not do any heartbeats or auto reconnection by default, so you have to worry about things like the connection timing out or being disconnected due to idling.

Because I'm doing about 4 different Node.js projects right now that involve databases, this is the configuration I've settled on -- for now. It basically reconnects and reattempts to make the query if it fails, or gives up after a few tries.

The fancy piece, `connection.query.apply(connection, parameters)`, basically takes all the parameters from the parent function and passes it into the query function like we used to.

If you're happy with this and it makes sense, go ahead and merge it. You should get a contribution credit today for the merge.
